### PR TITLE
`set -e` and fixes that it uncovered

### DIFF
--- a/tes3mp-deploy.sh
+++ b/tes3mp-deploy.sh
@@ -500,7 +500,7 @@ if [ $REBUILD ]; then
 
   echo -e "\n\n$CMAKE_PARAMS\n\n"
   cmake "$CODE" $CMAKE_PARAMS
-  { make -j $CORES 2>&1 || exit 1 } | tee "${BASE}"/build.log
+  ( make -j $CORES 2>&1 || exit 1 ) | tee "${BASE}"/build.log
 
   cd "$BASE"
 

--- a/tes3mp-deploy.sh
+++ b/tes3mp-deploy.sh
@@ -324,9 +324,8 @@ if [ $INSTALL ]; then
       echo -e "\n>> Unpacking and preparing Terra"
       cd "$DEPENDENCIES"
       unzip -o terra.zip
-      rm -r ./terra
-      mkdir terra
-      mv terra-* terra
+      rm -rf ./terra
+      mv --no-target-directory terra-* terra
       rm terra.zip
   fi
 

--- a/tes3mp-deploy.sh
+++ b/tes3mp-deploy.sh
@@ -531,10 +531,6 @@ if [ $REBUILD ]; then
   #ALL DONE
   echo -e "\n\n\nAll done! Press any key to exit.\nMay Vehk bestow his blessing upon your Muatra."
 
-  if [ ! $AUTO_UPGRADE ]; then
-    read
-  fi
-
 fi
 
 #MAKE PORTABLE PACKAGE

--- a/tes3mp-deploy.sh
+++ b/tes3mp-deploy.sh
@@ -321,12 +321,14 @@ if [ $INSTALL ]; then
       make -j$CORES
 
   else
+    if ! [ -e "$DEPENDENCIES"/terra ]; then
       echo -e "\n>> Unpacking and preparing Terra"
       cd "$DEPENDENCIES"
       unzip -o terra.zip
       rm -rf ./terra
       mv --no-target-directory terra-* terra
       rm terra.zip
+    fi
   fi
 
   cd "$BASE"

--- a/tes3mp-deploy.sh
+++ b/tes3mp-deploy.sh
@@ -323,8 +323,10 @@ if [ $INSTALL ]; then
   else
       echo -e "\n>> Unpacking and preparing Terra"
       cd "$DEPENDENCIES"
-      unzip terra.zip
-      mv --force terra-* terra
+      unzip -o terra.zip
+      rm -r ./terra
+      mkdir terra
+      mv terra-* terra
       rm terra.zip
   fi
 

--- a/tes3mp-deploy.sh
+++ b/tes3mp-deploy.sh
@@ -248,7 +248,7 @@ if [ $INSTALL ]; then
   if [ $BUILD_OSG ] && ! [ -e "$DEPENDENCIES"/osg ] ; then git clone https://github.com/openscenegraph/OpenSceneGraph.git "$DEPENDENCIES"/osg --depth 1; fi
   if [ $BUILD_BULLET ] && ! [ -e "$DEPENDENCIES"/bullet ]; then git clone https://github.com/bulletphysics/bullet3.git "$DEPENDENCIES"/bullet; fi # cannot --depth 1 because we check out specific revision
   ! [ -e "$DEPENDENCIES"/raknet ] && git clone https://github.com/TES3MP/RakNet.git "$DEPENDENCIES"/raknet --depth 1
-  if [ $BUILD_TERRA ] && ! [ -e "$DEPENDENCIES"/terra ]; then git clone https://github.com/zdevito/terra.git "$DEPENDENCIES"/terra --depth 1; else wget https://github.com/zdevito/terra/releases/download/release-2016-02-26/terra-Linux-x86_64-2fa8d0a.zip -O "$DEPENDENCIES"/terra.zip; fi
+  ! [ -e "$DEPENDENCIES"/terra ] && if [ $BUILD_TERRA ]; then git clone https://github.com/zdevito/terra.git "$DEPENDENCIES"/terra --depth 1; else wget https://github.com/zdevito/terra/releases/download/release-2016-02-26/terra-Linux-x86_64-2fa8d0a.zip -O "$DEPENDENCIES"/terra.zip; fi
   ! [ -e "$KEEPERS"/PluginExamples ] && git clone https://github.com/TES3MP/PluginExamples.git "$KEEPERS"/PluginExamples
 
   #COPY STATIC SERVER AND CLIENT CONFIGS

--- a/tes3mp-deploy.sh
+++ b/tes3mp-deploy.sh
@@ -248,7 +248,7 @@ if [ $INSTALL ]; then
   if [ $BUILD_OSG ] && ! [ -e "$DEPENDENCIES"/osg ] ; then git clone https://github.com/openscenegraph/OpenSceneGraph.git "$DEPENDENCIES"/osg --depth 1; fi
   if [ $BUILD_BULLET ] && ! [ -e "$DEPENDENCIES"/bullet ]; then git clone https://github.com/bulletphysics/bullet3.git "$DEPENDENCIES"/bullet; fi # cannot --depth 1 because we check out specific revision
   ! [ -e "$DEPENDENCIES"/raknet ] && git clone https://github.com/TES3MP/RakNet.git "$DEPENDENCIES"/raknet --depth 1
-  ! [ -e "$DEPENDENCIES"/terra ] && if [ $BUILD_TERRA ]; then git clone https://github.com/zdevito/terra.git "$DEPENDENCIES"/terra --depth 1; else wget https://github.com/zdevito/terra/releases/download/release-2016-02-26/terra-Linux-x86_64-2fa8d0a.zip -O "$DEPENDENCIES"/terra.zip; fi
+  if [ $BUILD_TERRA ] && ! [ -e "$DEPENDENCIES"/terra ]; then git clone https://github.com/zdevito/terra.git "$DEPENDENCIES"/terra --depth 1; else wget https://github.com/zdevito/terra/releases/download/release-2016-02-26/terra-Linux-x86_64-2fa8d0a.zip -O "$DEPENDENCIES"/terra.zip; fi
   ! [ -e "$KEEPERS"/PluginExamples ] && git clone https://github.com/TES3MP/PluginExamples.git "$KEEPERS"/PluginExamples
 
   #COPY STATIC SERVER AND CLIENT CONFIGS

--- a/tes3mp-deploy.sh
+++ b/tes3mp-deploy.sh
@@ -310,7 +310,7 @@ if [ $INSTALL ]; then
   cmake -DCMAKE_BUILD_TYPE=Release -DRAKNET_ENABLE_DLL=OFF -DRAKNET_ENABLE_SAMPLES=OFF -DRAKNET_ENABLE_STATIC=ON -DRAKNET_GENERATE_INCLUDE_ONLY_DIR=ON ..
   make -j$CORES
 
-  ln -s "$DEPENDENCIES"/raknet/include/RakNet "$DEPENDENCIES"/raknet/include/raknet #Stop being so case sensitive
+  ln -sf "$DEPENDENCIES"/raknet/include/RakNet "$DEPENDENCIES"/raknet/include/raknet #Stop being so case sensitive
 
   cd "$BASE"
 
@@ -324,7 +324,7 @@ if [ $INSTALL ]; then
       echo -e "\n>> Unpacking and preparing Terra"
       cd "$DEPENDENCIES"
       unzip terra.zip
-      mv terra-* terra
+      mv --force terra-* terra
       rm terra.zip
   fi
 

--- a/tes3mp-deploy.sh
+++ b/tes3mp-deploy.sh
@@ -498,7 +498,7 @@ if [ $REBUILD ]; then
 
   echo -e "\n\n$CMAKE_PARAMS\n\n"
   cmake "$CODE" $CMAKE_PARAMS
-  make -j $CORES 2>&1 | tee "${BASE}"/build.log
+  { make -j $CORES 2>&1 || exit 1 } | tee "${BASE}"/build.log
 
   cd "$BASE"
 

--- a/tes3mp-deploy.sh
+++ b/tes3mp-deploy.sh
@@ -501,7 +501,8 @@ if [ $REBUILD ]; then
 
   echo -e "\n\n$CMAKE_PARAMS\n\n"
   cmake "$CODE" $CMAKE_PARAMS
-  ( make -j $CORES 2>&1 || exit 1 ) | tee "${BASE}"/build.log
+  set -o pipefail # so that the "tee" below would not make build always return success
+  make -j $CORES 2>&1 | tee "${BASE}"/build.log
 
   cd "$BASE"
 


### PR DESCRIPTION
Abort script execution on any unexpected errors (build failures, missing sudo in chroot, network download errors, anything else going wrong).

Dramatically increases ease of debugging: the failure is the last message, not something you have to search the entire log for signs of.

This has uncovered a bug: bullet checkout to tag 2.86 failed due to shallow clone; that has been fixed.

Also downloads Terra archive only once instead of on every build.