### PR TITLE
Update to make work on Fedora

### DIFF
--- a/tes3mp-deploy.sh
+++ b/tes3mp-deploy.sh
@@ -316,7 +316,7 @@ if [ $INSTALL ]; then
               echo -e "Done!"
         fi
         sudo dnf --refresh groupinstall development-tools
-        sudo dnf --refresh install unzip wget cmake openal-devel OpenSceneGraph-qt-devel SDL2-devel qt5-devel boost-filesystem git boost-thread boost-program-options boost-system ffmpeg-devel ffmpeg-libs bullet-devel gcc-c++ mygui-devel unshield-devel tinyxml-devel cmake ncurses-c++-libs ncurses-devel #llvm35 llvm clang ncurses
+        sudo dnf --refresh install unzip wget cmake openal-devel OpenSceneGraph-qt-devel SDL2-devel qt5-devel boost-filesystem git boost-thread boost-program-options boost-system ffmpeg-devel ffmpeg-libs bullet-devel gcc-c++ mygui-devel unshield-devel tinyxml-devel cmake ncurses-c++-libs ncurses-devel luajit-devel #llvm35 llvm clang ncurses
         BUILD_BULLET=true
     ;;
 


### PR DESCRIPTION
For when running `./tes3mp-deploy -i -v master` on Fedora 28

Also I had to `git clone https://github.com/ThePhD/sol2 && cd sol2 && cmake . && sudo make install` to get TES3MP compilation going.